### PR TITLE
Add tests for gitignore matcher

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -130,7 +130,11 @@ impl RepoOps {
     }
 
     /// パスが.gitignoreパターンに一致するか判定する。
-    fn matches_gitignore_pattern(path: &str, pattern: &str) -> bool {
+    /// Determine if a path matches a .gitignore style pattern.
+    ///
+    /// The function is public so that integration tests can verify the
+    /// behaviour of pattern matching.
+    pub fn matches_gitignore_pattern(path: &str, pattern: &str) -> bool {
         let pattern = pattern.trim_start_matches('/');
         let path = path.trim_start_matches('/');
 

--- a/tests/repo_test.rs
+++ b/tests/repo_test.rs
@@ -1,0 +1,21 @@
+use vulnhuntrs::repo::RepoOps;
+
+#[test]
+fn test_matches_gitignore_leading_star() {
+    assert!(RepoOps::matches_gitignore_pattern("error.log", "*.log"));
+    assert!(RepoOps::matches_gitignore_pattern("logs/error.log", "*.log"));
+    assert!(!RepoOps::matches_gitignore_pattern("error.txt", "*.log"));
+}
+
+#[test]
+fn test_matches_gitignore_trailing_star() {
+    assert!(RepoOps::matches_gitignore_pattern("build/output.o", "build/*"));
+    assert!(RepoOps::matches_gitignore_pattern("build/sub/obj.o", "build/*"));
+    assert!(!RepoOps::matches_gitignore_pattern("target/output.o", "build/*"));
+}
+
+#[test]
+fn test_matches_gitignore_exact_match() {
+    assert!(RepoOps::matches_gitignore_pattern("src/main.rs", "src/main.rs"));
+    assert!(!RepoOps::matches_gitignore_pattern("src/lib.rs", "src/main.rs"));
+}


### PR DESCRIPTION
## Summary
- expose `matches_gitignore_pattern` for integration tests
- test leading `*`, trailing `*`, and exact `.gitignore` patterns

## Testing
- `cargo test --locked` *(fails: failed to get `anyhow` as a dependency)*