### PR TITLE
Add Ruby support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Vulnhuntrs is a security analysis tool designed to detect vulnerabilities in app
 
 - Static code analysis for security vulnerabilities
 - Multi-language support
+  - Supports Rust, Python, JavaScript, TypeScript, Go, Java, and Ruby.
 - Detailed vulnerability reports
 - Example vulnerable applications for testing
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,10 +109,15 @@ async fn main() -> Result<()> {
     }
 
     // SecurityRiskPatternsで該当ファイルを特定
-    let patterns = SecurityRiskPatterns::new(Language::Other);
     let mut pattern_files = Vec::new();
     for file_path in &files {
         if let Ok(content) = std::fs::read_to_string(file_path) {
+            let ext = file_path
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            let lang = Language::from_extension(ext);
+            let patterns = SecurityRiskPatterns::new(lang);
             if patterns.matches(&content) {
                 pattern_files.push(file_path.clone());
             }

--- a/tests/repo_test.rs
+++ b/tests/repo_test.rs
@@ -1,0 +1,15 @@
+use tempfile::tempdir;
+use vulnhuntrs::repo::RepoOps;
+
+#[test]
+fn test_ruby_files_are_recognized() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let file_path = dir.path().join("test.rb");
+    std::fs::write(&file_path, "puts 'hello'")?;
+
+    let repo = RepoOps::new(dir.path().to_path_buf());
+    let files = repo.get_relevant_files();
+
+    assert!(files.contains(&file_path));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- support `.rb` files in RepoOps
- detect security patterns using language-specific patterns
- document Ruby support in README
- test that RepoOps recognizes Ruby files

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*