### PR TITLE
Improve gitignore matching

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -130,7 +130,11 @@ impl RepoOps {
     }
 
     /// パスが.gitignoreパターンに一致するか判定する。
-    fn matches_gitignore_pattern(path: &str, pattern: &str) -> bool {
+    /// Determine if a path matches a .gitignore style pattern.
+    ///
+    /// The function is public so that integration tests can verify the
+    /// behaviour of pattern matching.
+    pub fn matches_gitignore_pattern(path: &str, pattern: &str) -> bool {
         let pattern = pattern.trim_start_matches('/');
         let path = path.trim_start_matches('/');
 
@@ -138,6 +142,13 @@ impl RepoOps {
             path.ends_with(&pattern[1..])
         } else if pattern.ends_with('*') {
             path.starts_with(&pattern[..pattern.len() - 1])
+        } else if !pattern.contains('/') {
+            if path == pattern {
+                true
+            } else {
+                path.split('/')
+                    .any(|segment| segment == pattern)
+            }
         } else {
             path == pattern || path.starts_with(&format!("{}/", pattern))
         }

--- a/tests/repo_test.rs
+++ b/tests/repo_test.rs
@@ -1,0 +1,33 @@
+use vulnhuntrs::repo::RepoOps;
+
+#[test]
+fn test_matches_gitignore_leading_star() {
+    assert!(RepoOps::matches_gitignore_pattern("error.log", "*.log"));
+    assert!(RepoOps::matches_gitignore_pattern("logs/error.log", "*.log"));
+    assert!(!RepoOps::matches_gitignore_pattern("error.txt", "*.log"));
+}
+
+#[test]
+fn test_matches_gitignore_trailing_star() {
+    assert!(RepoOps::matches_gitignore_pattern("build/output.o", "build/*"));
+    assert!(RepoOps::matches_gitignore_pattern("build/sub/obj.o", "build/*"));
+    assert!(!RepoOps::matches_gitignore_pattern("target/output.o", "build/*"));
+}
+
+#[test]
+fn test_matches_gitignore_exact_match() {
+    assert!(RepoOps::matches_gitignore_pattern("src/main.rs", "src/main.rs"));
+    assert!(!RepoOps::matches_gitignore_pattern("src/lib.rs", "src/main.rs"));
+}
+
+#[test]
+fn test_matches_gitignore_nested_directory() {
+    assert!(RepoOps::matches_gitignore_pattern(
+        "app/node_modules/package.json",
+        "node_modules"
+    ));
+    assert!(!RepoOps::matches_gitignore_pattern(
+        "app/modules/package.json",
+        "node_modules"
+    ));
+}


### PR DESCRIPTION
## Summary
- refine `matches_gitignore_pattern` to match directory names anywhere in the path
- add nested directory test case for `.gitignore` patterns

## Testing
- `cargo test --locked` *(fails: failed to get `anyhow` as a dependency)*