### PR TITLE
fix: correct Docker run examples in documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,14 @@ cargo run -- -r /path/to/project --min-confidence 7 --vuln-types RCE,SQLI
 docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/hikaruegashira/vulnhuntrs:latest --push .
 
 # Run with Docker
-docker run -v $(pwd):/app ghcr.io/hikaruegashira/vulnhuntrs analyze /app
+docker run -v $(pwd):/app ghcr.io/hikaruegashira/vulnhuntrs:latest -r /app
+
+docker run -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -v $(pwd):/app \
+  -v $(pwd)/reports:/reports \
+  --user $(id -u):$(id -g) \
+  ghcr.io/hikaruegashira/vulnhuntrs:latest \
+  -r /app --output-dir /reports --summary
 ```
 
 ## Architecture Overview

--- a/README.md
+++ b/README.md
@@ -77,9 +77,16 @@ URL: /cmdi?hostname=localhost;whoami
 ```bash
 docker pull ghcr.io/hikaruegashira/vulnhuntrs:latest
 
-docker run -v $(pwd):/app ghcr.io/hikaruegashira/vulnhuntrs analyze /app/path/to/target
+docker run -v $(pwd):/app ghcr.io/hikaruegashira/vulnhuntrs:latest -r /app/path/to/target
 
-docker run ghcr.io/hikaruegashira/vulnhuntrs --help
+docker run -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -v $(pwd):/app \
+  -v $(pwd)/reports:/reports \
+  --user $(id -u):$(id -g) \
+  ghcr.io/hikaruegashira/vulnhuntrs:latest \
+  -r /app/path/to/target --output-dir /reports --summary
+
+docker run ghcr.io/hikaruegashira/vulnhuntrs:latest --help
 ```
 
 ### multi architecture image build


### PR DESCRIPTION
## Summary
- Fixed Docker run command examples to use correct CLI syntax (`-r` flag instead of `analyze` subcommand)
- Added proper mount configuration for report output with user permissions to avoid permission errors

## Test plan
- [x] Verify Docker commands work with the corrected syntax
- [x] Test report output functionality with proper mounts
- [x] Confirm documentation accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)