### PR TITLE
fix: configure Next.js basePath for GitHub Pages CSS loading

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -32,4 +32,3 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: website/out
-        cname: vulnhuntrs-docs.pages.dev

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -1,8 +1,12 @@
 import type { NextConfig } from 'next';
 
+const isProd = process.env.NODE_ENV === 'production';
+
 const config: NextConfig = {
   output: 'export',
   trailingSlash: true,
+  basePath: isProd ? '/vulnhuntrs' : '',
+  assetPrefix: isProd ? '/vulnhuntrs' : '',
   images: {
     unoptimized: true,
   },


### PR DESCRIPTION
## Summary
- Configure Next.js `basePath` and `assetPrefix` for GitHub Pages deployment
- Remove custom CNAME to use standard GitHub Pages subdirectory approach
- Fix CSS not loading on hikaruegashira.github.io/vulnhuntrs/

## Test plan
- [x] Build website locally with production configuration
- [x] Verify generated HTML has correct asset paths with `/vulnhuntrs/` prefix
- [ ] Deploy to GitHub Pages and verify CSS loads correctly

🤖 Generated with [Claude Code](https://claude.ai/code)