### PR TITLE
fix: resolve cargo-deny license issues and upgrade tree-sitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,10 +373,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "encode_unicode"
@@ -1605,6 +1605,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2040,13 +2041,14 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "a7cf18d43cbf0bfca51f657132cc616a5097edc4424d538bae6fa60142eaf9f0"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]
@@ -2155,7 +2157,7 @@ dependencies = [
  "async-trait",
  "cc",
  "clap",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "futures",
  "genai",
@@ -2171,7 +2173,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-test",
- "tree-sitter 0.24.7",
+ "tree-sitter 0.25.6",
  "tree-sitter-ruby",
  "tree-sitter-typescript",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ cc = "1.0"
 snapshot-test = []
 
 [dependencies]
-tree-sitter = "0.24.6"
+tree-sitter = "0.25.6"
 git2 = "0.18"
 streaming-iterator = "0.1"
 tree-sitter-typescript = { version = "0.20" }
@@ -25,7 +25,7 @@ env_logger = "0.11"
 anyhow = "1.0"
 async-trait = "0.1"
 quick-xml = { version = "0.31", features = ["serialize"] }
-dotenv = "0.15"
+dotenvy = "0.15"
 genai = "0.3.5"
 futures = { version = "0.3", features = ["thread-pool"] }
 tree-sitter-ruby = "0.20"

--- a/build.rs
+++ b/build.rs
@@ -74,7 +74,6 @@ fn main() {
         .flag("-Wno-unused-parameter")
         .compile("tree-sitter-tsx");
 
-
     cc::Build::new()
         .include(&dir)
         .include(&tree_sitter_dir)
@@ -82,7 +81,6 @@ fn main() {
         .file(dir.join("tree-sitter-ruby/src/scanner.c"))
         .flag("-Wno-unused-parameter")
         .compile("tree-sitter-ruby");
-
 
     // Add library search path
     println!("cargo:rustc-link-search=native={}", out_dir.display());

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,13 @@
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause", 
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "AGPL-3.0",
+    "CDLA-Permissive-2.0",
+]

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -8,8 +8,8 @@ use std::path::PathBuf;
 
 use crate::parser::CodeParser;
 use crate::prompts::{self, vuln_specific};
-use crate::response::{response_json_schema, Response};
-use crate::security_patterns::{SecurityRiskPatterns, PatternType, Language};
+use crate::response::{Response, response_json_schema};
+use crate::security_patterns::{Language, PatternType, SecurityRiskPatterns};
 
 fn create_api_client() -> Client {
     let client_config = ClientConfig::default().with_chat_options(
@@ -104,7 +104,9 @@ pub async fn analyze_file(
     debug!("[PROMPT]\n{}", prompt);
 
     let chat_req = ChatRequest::new(vec![
-        ChatMessage::system("You are a security vulnerability analyzer. You must reply with exactly one JSON object that matches this schema: { \"scratchpad\": string, \"analysis\": string, \"poc\": string, \"confidence_score\": integer, \"vulnerability_types\": array of strings, \"context_code\": array of objects with { \"name\": string, \"reason\": string, \"code_line\": string } }. Do not include any explanatory text outside the JSON object."),
+        ChatMessage::system(
+            "You are a security vulnerability analyzer. You must reply with exactly one JSON object that matches this schema: { \"scratchpad\": string, \"analysis\": string, \"poc\": string, \"confidence_score\": integer, \"vulnerability_types\": array of strings, \"context_code\": array of objects with { \"name\": string, \"reason\": string, \"code_line\": string } }. Do not include any explanatory text outside the JSON object.",
+        ),
         ChatMessage::user(&prompt),
     ]);
 
@@ -112,8 +114,9 @@ pub async fn analyze_file(
     let chat_content = execute_chat_request(&json_client, model, chat_req).await?;
     debug!("[LLM Response]\n{}", chat_content);
     let mut response: Response = parse_json_response(&chat_content)?;
-    
-    response.confidence_score = crate::response::Response::normalize_confidence_score(response.confidence_score);
+
+    response.confidence_score =
+        crate::response::Response::normalize_confidence_score(response.confidence_score);
 
     info!("Initial analysis complete");
 
@@ -126,10 +129,7 @@ pub async fn analyze_file(
             let mut stored_code_definitions: Vec<(PathBuf, crate::parser::Definition)> = Vec::new();
 
             {
-                info!(
-                    "Performing vuln-specific analysis for {:?}",
-                    vuln_type
-                );
+                info!("Performing vuln-specific analysis for {:?}", vuln_type);
                 if verbosity > 0 {
                     println!(
                         "🔎 [{}] 脆弱性タイプ: {:?} の詳細解析",
@@ -180,8 +180,11 @@ pub async fn analyze_file(
                 let chat_content = execute_chat_request(&json_client, model, chat_req).await?;
                 debug!("[LLM Response]\n{}", chat_content);
                 let mut vuln_response: Response = parse_json_response(&chat_content)?;
-                
-                vuln_response.confidence_score = crate::response::Response::normalize_confidence_score(vuln_response.confidence_score);
+
+                vuln_response.confidence_score =
+                    crate::response::Response::normalize_confidence_score(
+                        vuln_response.confidence_score,
+                    );
 
                 if verbosity > 0 {
                     debug!(
@@ -209,7 +212,8 @@ pub async fn analyze_file(
                 }
 
                 // Get language for pattern detection
-                let file_extension = file_path.extension()
+                let file_extension = file_path
+                    .extension()
                     .and_then(|ext| ext.to_str())
                     .unwrap_or("");
                 let language = Language::from_extension(file_extension);
@@ -223,7 +227,7 @@ pub async fn analyze_file(
                     {
                         // Determine pattern type to choose appropriate search method
                         let pattern_type = patterns.get_pattern_type(&context.name);
-                        
+
                         match pattern_type {
                             Some(PatternType::Source) => {
                                 // For sources, use find_references to track data flow forward

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use std::path::PathBuf;
 use vulnhuntrs::analyzer::analyze_file;
 use vulnhuntrs::pattern_generator::generate_custom_patterns;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,19 +52,19 @@ struct Args {
     /// Output directory for markdown reports
     #[arg(long)]
     output_dir: Option<PathBuf>,
-    
+
     /// 最小信頼度スコア（これ以上のスコアを持つ脆弱性のみ表示）
     #[arg(long, default_value = "0")]
     min_confidence: i32,
-    
+
     /// 特定の脆弱性タイプでフィルタリング（カンマ区切りで複数指定可）
     #[arg(long)]
     vuln_types: Option<String>,
-    
+
     /// サマリーレポートを生成する
     #[arg(long)]
     summary: bool,
-    
+
     /// カスタムパターンを生成する（現在のディレクトリを解析してセキュリティパターンを自動検出）
     #[arg(long)]
     generate_patterns: bool,
@@ -119,10 +119,7 @@ async fn main() -> Result<()> {
     let mut pattern_files = Vec::new();
     for file_path in &files {
         if let Ok(content) = std::fs::read_to_string(file_path) {
-            let ext = file_path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
+            let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
             let lang = Language::from_extension(ext);
             let patterns = SecurityRiskPatterns::new(lang);
             if patterns.matches(&content) {
@@ -162,7 +159,11 @@ async fn main() -> Result<()> {
 
             let mut repo = RepoOps::new((*root_dir).clone());
             if let Err(e) = repo.add_file_to_parser(&file_path) {
-                println!("❌ ファイルのパース追加に失敗: {}: {}", file_path.display(), e);
+                println!(
+                    "❌ ファイルのパース追加に失敗: {}: {}",
+                    file_path.display(),
+                    e
+                );
                 return None;
             }
             let context = match repo.collect_context_for_security_pattern(&file_path) {
@@ -173,21 +174,28 @@ async fn main() -> Result<()> {
                 }
             };
 
-            let analysis_result = match analyze_file(&file_path, &model, &files, verbosity, &context, 0).await {
-                Ok(res) => res,
-                Err(e) => {
-                    println!("❌ 解析に失敗: {}: {}", file_path.display(), e);
-                    return None;
-                }
-            };
+            let analysis_result =
+                match analyze_file(&file_path, &model, &files, verbosity, &context, 0).await {
+                    Ok(res) => res,
+                    Err(e) => {
+                        println!("❌ 解析に失敗: {}: {}", file_path.display(), e);
+                        return None;
+                    }
+                };
 
-            if analysis_result.vulnerability_types.is_empty() || analysis_result.confidence_score < 1 {
+            if analysis_result.vulnerability_types.is_empty()
+                || analysis_result.confidence_score < 1
+            {
                 return None;
             }
 
             if let Some(ref output_dir) = output_dir {
                 if let Err(e) = std::fs::create_dir_all(output_dir) {
-                    println!("❌ 出力ディレクトリ作成に失敗: {}: {}", output_dir.display(), e);
+                    println!(
+                        "❌ 出力ディレクトリ作成に失敗: {}: {}",
+                        output_dir.display(),
+                        e
+                    );
                     return None;
                 }
                 let fname = file_path
@@ -197,14 +205,18 @@ async fn main() -> Result<()> {
                 let mut out_path = output_dir.clone();
                 out_path.push(fname);
                 if let Err(e) = std::fs::write(&out_path, analysis_result.to_markdown()) {
-                    println!("❌ Markdownレポート出力に失敗: {}: {}", out_path.display(), e);
+                    println!(
+                        "❌ Markdownレポート出力に失敗: {}: {}",
+                        out_path.display(),
+                        e
+                    );
                     return None;
                 }
                 println!("📝 Markdownレポートを出力: {}", out_path.display());
             }
 
             analysis_result.print_readable();
-            
+
             Some((file_path, analysis_result))
         })
     });
@@ -213,15 +225,15 @@ async fn main() -> Result<()> {
     for (file_path, response) in results.into_iter().flatten().flatten() {
         summary.add_result(file_path, response);
     }
-    
+
     summary.sort_by_confidence();
-    
+
     let mut filtered_summary = if args.min_confidence > 0 {
         summary.filter_by_min_confidence(args.min_confidence)
     } else {
         summary
     };
-    
+
     if let Some(types_str) = args.vuln_types {
         let vuln_types: Vec<VulnType> = types_str
             .split(',')
@@ -236,20 +248,28 @@ async fn main() -> Result<()> {
                 other => VulnType::Other(other.to_string()),
             })
             .collect();
-        
+
         filtered_summary = filtered_summary.filter_by_vuln_types(&vuln_types);
     }
-    
+
     if args.summary {
         if let Some(ref output_dir) = args.output_dir {
             if let Err(e) = std::fs::create_dir_all(output_dir) {
-                println!("❌ 出力ディレクトリ作成に失敗: {}: {}", output_dir.display(), e);
+                println!(
+                    "❌ 出力ディレクトリ作成に失敗: {}: {}",
+                    output_dir.display(),
+                    e
+                );
             } else {
                 if !filtered_summary.results.is_empty() {
                     let mut summary_path = output_dir.clone();
                     summary_path.push("summary.md");
                     if let Err(e) = std::fs::write(&summary_path, filtered_summary.to_markdown()) {
-                        println!("❌ サマリーレポート出力に失敗: {}: {}", summary_path.display(), e);
+                        println!(
+                            "❌ サマリーレポート出力に失敗: {}: {}",
+                            summary_path.display(),
+                            e
+                        );
                     } else {
                         println!("📊 サマリーレポートを出力: {}", summary_path.display());
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -83,8 +83,7 @@ impl CodeParser {
             "typescript"
         } else if language == &unsafe { tree_sitter_java() } {
             "java"
-        }
-        else if language == &unsafe { tree_sitter_go() } {
+        } else if language == &unsafe { tree_sitter_go() } {
             "go"
         } else if language == &unsafe { tree_sitter_rust() } {
             "rust"

--- a/src/pattern_generator.rs
+++ b/src/pattern_generator.rs
@@ -232,6 +232,8 @@ pub fn write_patterns_to_file(
         Language::Java => "Java",
         Language::Go => "Go",
         Language::Ruby => "Ruby",
+        Language::C => "C",
+        Language::Cpp => "Cpp",
         Language::Other => return Ok(()),
     };
 

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -38,6 +38,13 @@ impl RepoOps {
             "go".to_string(),
             "java".to_string(),
             "rb".to_string(),
+            "c".to_string(),
+            "h".to_string(),
+            "cpp".to_string(),
+            "cxx".to_string(),
+            "cc".to_string(),
+            "hpp".to_string(),
+            "hxx".to_string(),
         ];
 
         Self {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
 use crate::security_patterns::SecurityRiskPatterns;
+use anyhow::Result;
 use std::{
-    fs::{read_dir, read_to_string, File},
+    fs::{File, read_dir, read_to_string},
     io::{BufRead, BufReader, Result as IoResult},
     path::{Path, PathBuf},
 };
@@ -135,8 +135,7 @@ impl RepoOps {
             if path == pattern {
                 true
             } else {
-                path.split('/')
-                    .any(|segment| segment == pattern)
+                path.split('/').any(|segment| segment == pattern)
             }
         } else {
             path == pattern || path.starts_with(&format!("{}/", pattern))
@@ -172,10 +171,7 @@ impl RepoOps {
         let mut network_files = Vec::new();
         for file_path in files {
             if let Ok(content) = read_to_string(file_path) {
-                let ext = file_path
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .unwrap_or("");
+                let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
                 let lang = crate::security_patterns::Language::from_extension(ext);
                 let patterns = SecurityRiskPatterns::new(lang);
                 if patterns.matches(&content) {

--- a/src/security_patterns.rs
+++ b/src/security_patterns.rs
@@ -67,7 +67,7 @@ impl SecurityRiskPatterns {
             .unwrap();
 
         let mut source_patterns = Vec::new();
-        let mut sink_patterns = Vec::new(); 
+        let mut sink_patterns = Vec::new();
         let mut validate_patterns = Vec::new();
         let mut pattern_type_map = HashMap::new();
 
@@ -95,18 +95,26 @@ impl SecurityRiskPatterns {
             }
         }
 
-        Self { 
+        Self {
             source_patterns,
-            sink_patterns, 
+            sink_patterns,
             validate_patterns,
             pattern_type_map,
         }
     }
 
     pub fn matches(&self, content: &str) -> bool {
-        self.source_patterns.iter().any(|pattern| pattern.is_match(content))
-            || self.sink_patterns.iter().any(|pattern| pattern.is_match(content))
-            || self.validate_patterns.iter().any(|pattern| pattern.is_match(content))
+        self.source_patterns
+            .iter()
+            .any(|pattern| pattern.is_match(content))
+            || self
+                .sink_patterns
+                .iter()
+                .any(|pattern| pattern.is_match(content))
+            || self
+                .validate_patterns
+                .iter()
+                .any(|pattern| pattern.is_match(content))
     }
 
     /// パターンの種類を取得する。
@@ -125,9 +133,7 @@ impl SecurityRiskPatterns {
         use Language::*;
 
         let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        let yaml_path = manifest_dir
-            .join("security_patterns")
-            .join("patterns.yml");
+        let yaml_path = manifest_dir.join("security_patterns").join("patterns.yml");
         let content = fs::read_to_string(&yaml_path)
             .unwrap_or_else(|_| panic!("failed to read {}", yaml_path.display()));
         let raw_map: HashMap<String, LanguagePatterns> =

--- a/src/security_patterns.rs
+++ b/src/security_patterns.rs
@@ -13,6 +13,8 @@ pub enum Language {
     Java,
     Go,
     Ruby,
+    C,
+    Cpp,
     Other,
 }
 
@@ -26,6 +28,8 @@ impl Language {
             "java" => Language::Java,
             "go" => Language::Go,
             "rb" => Language::Ruby,
+            "c" | "h" => Language::C,
+            "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Language::Cpp,
             _ => Language::Other,
         }
     }
@@ -149,6 +153,8 @@ impl SecurityRiskPatterns {
                 "Java" => Java,
                 "Go" => Go,
                 "Ruby" => Ruby,
+                "C" => C,
+                "Cpp" => Cpp,
                 "Other" => Other,
                 _ => continue,
             };

--- a/tests/analyzer_unit_test.rs
+++ b/tests/analyzer_unit_test.rs
@@ -1,8 +1,8 @@
+use std::io::Write;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
 use vulnhuntrs::parser::{Context, Definition};
 use vulnhuntrs::response::Response;
-use std::io::Write;
 
 // Mock functions for testing
 #[tokio::test]
@@ -10,23 +10,23 @@ async fn test_analyze_empty_file() -> anyhow::Result<()> {
     // Create empty temporary file
     let temp_file = NamedTempFile::new()?;
     let file_path = temp_file.path().to_path_buf();
-    
+
     // Create empty context
     let context = Context {
         definitions: vec![],
     };
-    
+
     // Test with mock model (this would require actual API key in real scenario)
     // For unit test, we'll test the empty file handling specifically
     let result = analyze_empty_file_logic(&file_path).await?;
-    
+
     assert_eq!(result.scratchpad, "");
     assert_eq!(result.analysis, "");
     assert_eq!(result.poc, "");
     assert_eq!(result.confidence_score, 0);
     assert_eq!(result.vulnerability_types.len(), 0);
     assert_eq!(result.context_code.len(), 0);
-    
+
     Ok(())
 }
 
@@ -36,7 +36,7 @@ async fn test_analyze_file_with_basic_content() -> anyhow::Result<()> {
     let mut temp_file = NamedTempFile::new()?;
     writeln!(temp_file, "print('Hello, World!')")?;
     let file_path = temp_file.path().to_path_buf();
-    
+
     // Create context with a mock definition
     let context = Context {
         definitions: vec![Definition {
@@ -46,12 +46,12 @@ async fn test_analyze_file_with_basic_content() -> anyhow::Result<()> {
             end_byte: 25,
         }],
     };
-    
+
     // Test basic file processing logic (without actual LLM call)
     let content = std::fs::read_to_string(&file_path)?;
     assert!(!content.is_empty());
     assert!(content.contains("Hello, World!"));
-    
+
     Ok(())
 }
 
@@ -61,7 +61,8 @@ fn test_context_text_generation() {
         definitions: vec![
             Definition {
                 name: "vulnerable_function".to_string(),
-                source: "def vulnerable_function(user_input):\n    os.system(user_input)".to_string(),
+                source: "def vulnerable_function(user_input):\n    os.system(user_input)"
+                    .to_string(),
                 start_byte: 0,
                 end_byte: 50,
             },
@@ -73,7 +74,7 @@ fn test_context_text_generation() {
             },
         ],
     };
-    
+
     let mut context_text = String::new();
     if !context.definitions.is_empty() {
         context_text.push_str("\nContext Definitions:\n");
@@ -84,7 +85,7 @@ fn test_context_text_generation() {
             ));
         }
     }
-    
+
     assert!(context_text.contains("vulnerable_function"));
     assert!(context_text.contains("safe_function"));
     assert!(context_text.contains("os.system"));
@@ -104,7 +105,7 @@ async fn analyze_empty_file_logic(file_path: &PathBuf) -> anyhow::Result<Respons
             context_code: vec![],
         });
     }
-    
+
     // For non-empty files, return a mock response
     Ok(Response {
         scratchpad: "File processed".to_string(),
@@ -126,10 +127,10 @@ fn test_parse_json_response_valid() {
         "vulnerability_types": [],
         "context_code": []
     }"#;
-    
+
     let result: Result<Response, _> = serde_json::from_str(json_content);
     assert!(result.is_ok());
-    
+
     let response = result.unwrap();
     assert_eq!(response.scratchpad, "Test scratchpad");
     assert_eq!(response.analysis, "Test analysis");
@@ -139,7 +140,7 @@ fn test_parse_json_response_valid() {
 #[test]
 fn test_parse_json_response_invalid() {
     let invalid_json = r#"{ invalid json content"#;
-    
+
     let result: Result<Response, _> = serde_json::from_str(invalid_json);
     assert!(result.is_err());
 }

--- a/tests/main_unit_test.rs
+++ b/tests/main_unit_test.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
-use vulnhuntrs::response::{AnalysisSummary, VulnType, Response};
 use vulnhuntrs::response::FileAnalysisResult;
+use vulnhuntrs::response::{AnalysisSummary, Response, VulnType};
 
 #[test]
 fn test_vuln_type_parsing() {
@@ -19,7 +19,7 @@ fn test_vuln_type_parsing() {
             other => VulnType::Other(other.to_string()),
         })
         .collect();
-    
+
     assert_eq!(vuln_types.len(), 4);
     assert_eq!(vuln_types[0], VulnType::LFI);
     assert_eq!(vuln_types[1], VulnType::RCE);
@@ -43,7 +43,7 @@ fn test_vuln_type_parsing_with_unknown_type() {
             other => VulnType::Other(other.to_string()),
         })
         .collect();
-    
+
     assert_eq!(vuln_types.len(), 3);
     assert_eq!(vuln_types[0], VulnType::LFI);
     assert_eq!(vuln_types[1], VulnType::Other("UNKNOWN_TYPE".to_string()));
@@ -53,7 +53,7 @@ fn test_vuln_type_parsing_with_unknown_type() {
 #[test]
 fn test_analysis_summary_creation() {
     let mut summary = AnalysisSummary::new();
-    
+
     // Create mock responses
     let response1 = Response {
         scratchpad: "Test scratchpad 1".to_string(),
@@ -63,7 +63,7 @@ fn test_analysis_summary_creation() {
         vulnerability_types: vec![VulnType::RCE],
         context_code: vec![],
     };
-    
+
     let response2 = Response {
         scratchpad: "Test scratchpad 2".to_string(),
         analysis: "Test analysis 2".to_string(),
@@ -72,11 +72,11 @@ fn test_analysis_summary_creation() {
         vulnerability_types: vec![VulnType::SQLI],
         context_code: vec![],
     };
-    
+
     // Add results to summary
     summary.add_result(PathBuf::from("/test/file1.py"), response1);
     summary.add_result(PathBuf::from("/test/file2.py"), response2);
-    
+
     assert_eq!(summary.results.len(), 2);
     assert_eq!(summary.results[0].response.confidence_score, 8);
     assert_eq!(summary.results[1].response.confidence_score, 6);
@@ -85,7 +85,7 @@ fn test_analysis_summary_creation() {
 #[test]
 fn test_analysis_summary_filtering_by_confidence() {
     let mut summary = AnalysisSummary::new();
-    
+
     // Create responses with different confidence scores
     let high_confidence = Response {
         scratchpad: "High confidence".to_string(),
@@ -95,7 +95,7 @@ fn test_analysis_summary_filtering_by_confidence() {
         vulnerability_types: vec![VulnType::RCE],
         context_code: vec![],
     };
-    
+
     let low_confidence = Response {
         scratchpad: "Low confidence".to_string(),
         analysis: "Low confidence analysis".to_string(),
@@ -104,13 +104,13 @@ fn test_analysis_summary_filtering_by_confidence() {
         vulnerability_types: vec![VulnType::XSS],
         context_code: vec![],
     };
-    
+
     summary.add_result(PathBuf::from("/test/high.py"), high_confidence);
     summary.add_result(PathBuf::from("/test/low.py"), low_confidence);
-    
+
     // Filter by minimum confidence 5
     let filtered = summary.filter_by_min_confidence(5);
-    
+
     assert_eq!(filtered.results.len(), 1);
     assert_eq!(filtered.results[0].response.confidence_score, 9);
 }
@@ -118,7 +118,7 @@ fn test_analysis_summary_filtering_by_confidence() {
 #[test]
 fn test_analysis_summary_filtering_by_vuln_types() {
     let mut summary = AnalysisSummary::new();
-    
+
     let rce_response = Response {
         scratchpad: "RCE vulnerability".to_string(),
         analysis: "RCE analysis".to_string(),
@@ -127,7 +127,7 @@ fn test_analysis_summary_filtering_by_vuln_types() {
         vulnerability_types: vec![VulnType::RCE],
         context_code: vec![],
     };
-    
+
     let sqli_response = Response {
         scratchpad: "SQLI vulnerability".to_string(),
         analysis: "SQLI analysis".to_string(),
@@ -136,7 +136,7 @@ fn test_analysis_summary_filtering_by_vuln_types() {
         vulnerability_types: vec![VulnType::SQLI],
         context_code: vec![],
     };
-    
+
     let xss_response = Response {
         scratchpad: "XSS vulnerability".to_string(),
         analysis: "XSS analysis".to_string(),
@@ -145,25 +145,40 @@ fn test_analysis_summary_filtering_by_vuln_types() {
         vulnerability_types: vec![VulnType::XSS],
         context_code: vec![],
     };
-    
+
     summary.add_result(PathBuf::from("/test/rce.py"), rce_response);
     summary.add_result(PathBuf::from("/test/sqli.py"), sqli_response);
     summary.add_result(PathBuf::from("/test/xss.py"), xss_response);
-    
+
     // Filter by specific vulnerability types
     let filter_types = vec![VulnType::RCE, VulnType::SQLI];
     let filtered = summary.filter_by_vuln_types(&filter_types);
-    
+
     assert_eq!(filtered.results.len(), 2);
-    assert!(filtered.results.iter().any(|r| r.response.vulnerability_types.contains(&VulnType::RCE)));
-    assert!(filtered.results.iter().any(|r| r.response.vulnerability_types.contains(&VulnType::SQLI)));
-    assert!(!filtered.results.iter().any(|r| r.response.vulnerability_types.contains(&VulnType::XSS)));
+    assert!(
+        filtered
+            .results
+            .iter()
+            .any(|r| r.response.vulnerability_types.contains(&VulnType::RCE))
+    );
+    assert!(
+        filtered
+            .results
+            .iter()
+            .any(|r| r.response.vulnerability_types.contains(&VulnType::SQLI))
+    );
+    assert!(
+        !filtered
+            .results
+            .iter()
+            .any(|r| r.response.vulnerability_types.contains(&VulnType::XSS))
+    );
 }
 
 #[test]
 fn test_analysis_summary_sorting_by_confidence() {
     let mut summary = AnalysisSummary::new();
-    
+
     // Add results in random order
     let responses = [
         (PathBuf::from("/test/medium.py"), 5),
@@ -171,7 +186,7 @@ fn test_analysis_summary_sorting_by_confidence() {
         (PathBuf::from("/test/low.py"), 2),
         (PathBuf::from("/test/very_high.py"), 10),
     ];
-    
+
     for (path, confidence) in responses {
         let response = Response {
             scratchpad: format!("Confidence {}", confidence),
@@ -183,9 +198,9 @@ fn test_analysis_summary_sorting_by_confidence() {
         };
         summary.add_result(path, response);
     }
-    
+
     summary.sort_by_confidence();
-    
+
     // Should be sorted in descending order by confidence
     assert_eq!(summary.results[0].response.confidence_score, 10);
     assert_eq!(summary.results[1].response.confidence_score, 9);
@@ -198,7 +213,7 @@ fn test_pathbuf_from_string() {
     // Test path handling logic
     let path_str = "/tmp/test/vulnerable.py";
     let path = PathBuf::from(path_str);
-    
+
     assert_eq!(path.to_string_lossy(), path_str);
     assert!(path.is_absolute());
     assert_eq!(path.extension().unwrap(), "py");
@@ -215,7 +230,7 @@ fn test_model_default_value() {
 fn test_verbosity_levels() {
     // Test verbosity level handling
     let verbosity_levels = [0u8, 1u8, 2u8, 3u8];
-    
+
     for level in verbosity_levels {
         match level {
             0 => assert_eq!(level, 0), // No verbose output

--- a/tests/prompts_unit_test.rs
+++ b/tests/prompts_unit_test.rs
@@ -1,9 +1,6 @@
 use vulnhuntrs::prompts::{
-    SYS_PROMPT_TEMPLATE, 
-    INITIAL_ANALYSIS_PROMPT_TEMPLATE,
-    ANALYSIS_APPROACH_TEMPLATE,
-    GUIDELINES_TEMPLATE,
-    vuln_specific
+    ANALYSIS_APPROACH_TEMPLATE, GUIDELINES_TEMPLATE, INITIAL_ANALYSIS_PROMPT_TEMPLATE,
+    SYS_PROMPT_TEMPLATE, vuln_specific,
 };
 use vulnhuntrs::response::VulnType;
 
@@ -53,7 +50,7 @@ fn test_prompt_templates_are_non_empty() {
         ANALYSIS_APPROACH_TEMPLATE,
         GUIDELINES_TEMPLATE,
     ];
-    
+
     for template in templates {
         assert!(!template.is_empty());
         assert!(template.len() > 10); // Reasonable minimum length
@@ -62,25 +59,23 @@ fn test_prompt_templates_are_non_empty() {
 
 #[test]
 fn test_prompt_templates_contain_analysis_keywords() {
-    let analysis_keywords = [
-        "分析",
-        "脆弱性",
-        "セキュリティ",
-        "コード",
-    ];
-    
+    let analysis_keywords = ["分析", "脆弱性", "セキュリティ", "コード"];
+
     let templates = [
         SYS_PROMPT_TEMPLATE,
         INITIAL_ANALYSIS_PROMPT_TEMPLATE,
         ANALYSIS_APPROACH_TEMPLATE,
         GUIDELINES_TEMPLATE,
     ];
-    
+
     for template in templates {
         let contains_analysis_keywords = analysis_keywords
             .iter()
             .any(|keyword| template.contains(keyword));
-        assert!(contains_analysis_keywords, "Template should contain analysis keywords");
+        assert!(
+            contains_analysis_keywords,
+            "Template should contain analysis keywords"
+        );
     }
 }
 
@@ -95,38 +90,45 @@ fn test_vuln_specific_module_exists() {
 #[test]
 fn test_vuln_info_map_contains_common_types() {
     let vuln_info_map = vuln_specific::get_vuln_specific_info();
-    
+
     // Test that common vulnerability types are present
-    let common_types = [
-        VulnType::RCE,
-        VulnType::SQLI,
-        VulnType::XSS,
-        VulnType::LFI,
-    ];
-    
+    let common_types = [VulnType::RCE, VulnType::SQLI, VulnType::XSS, VulnType::LFI];
+
     for vuln_type in common_types {
-        assert!(vuln_info_map.contains_key(&vuln_type), 
-               "Should contain vulnerability type: {:?}", vuln_type);
+        assert!(
+            vuln_info_map.contains_key(&vuln_type),
+            "Should contain vulnerability type: {:?}",
+            vuln_type
+        );
     }
 }
 
 #[test]
 fn test_vuln_info_structure() {
     let vuln_info_map = vuln_specific::get_vuln_specific_info();
-    
+
     for (vuln_type, vuln_info) in &vuln_info_map {
         // Each vulnerability type should have non-empty prompt
-        assert!(!vuln_info.prompt.is_empty(), 
-               "Prompt should not be empty for {:?}", vuln_type);
-        
+        assert!(
+            !vuln_info.prompt.is_empty(),
+            "Prompt should not be empty for {:?}",
+            vuln_type
+        );
+
         // Prompt should be reasonably long
-        assert!(vuln_info.prompt.len() > 20, 
-               "Prompt should be substantial for {:?}", vuln_type);
-        
+        assert!(
+            vuln_info.prompt.len() > 20,
+            "Prompt should be substantial for {:?}",
+            vuln_type
+        );
+
         // Bypasses can be empty but if present should be non-empty strings
         for bypass in &vuln_info.bypasses {
-            assert!(!bypass.is_empty(), 
-                   "Bypass strings should not be empty for {:?}", vuln_type);
+            assert!(
+                !bypass.is_empty(),
+                "Bypass strings should not be empty for {:?}",
+                vuln_type
+            );
         }
     }
 }
@@ -135,15 +137,17 @@ fn test_vuln_info_structure() {
 fn test_rce_specific_prompt() {
     let vuln_info_map = vuln_specific::get_vuln_specific_info();
     let rce_info = vuln_info_map.get(&VulnType::RCE);
-    
+
     assert!(rce_info.is_some());
     let rce_info = rce_info.unwrap();
-    
+
     // RCE prompt should contain relevant keywords (English or Japanese)
-    assert!(rce_info.prompt.contains("コマンド") || 
-           rce_info.prompt.contains("実行") ||
-           rce_info.prompt.contains("Remote Code Execution") ||
-           rce_info.prompt.contains("Code Execution"));
+    assert!(
+        rce_info.prompt.contains("コマンド")
+            || rce_info.prompt.contains("実行")
+            || rce_info.prompt.contains("Remote Code Execution")
+            || rce_info.prompt.contains("Code Execution")
+    );
     assert!(!rce_info.prompt.is_empty());
 }
 
@@ -151,14 +155,16 @@ fn test_rce_specific_prompt() {
 fn test_sqli_specific_prompt() {
     let vuln_info_map = vuln_specific::get_vuln_specific_info();
     let sqli_info = vuln_info_map.get(&VulnType::SQLI);
-    
+
     assert!(sqli_info.is_some());
     let sqli_info = sqli_info.unwrap();
-    
+
     // SQL injection prompt should contain relevant keywords
-    assert!(sqli_info.prompt.contains("SQL") || 
-           sqli_info.prompt.contains("データベース") ||
-           sqli_info.prompt.contains("クエリ"));
+    assert!(
+        sqli_info.prompt.contains("SQL")
+            || sqli_info.prompt.contains("データベース")
+            || sqli_info.prompt.contains("クエリ")
+    );
     assert!(!sqli_info.prompt.is_empty());
 }
 
@@ -166,15 +172,17 @@ fn test_sqli_specific_prompt() {
 fn test_xss_specific_prompt() {
     let vuln_info_map = vuln_specific::get_vuln_specific_info();
     let xss_info = vuln_info_map.get(&VulnType::XSS);
-    
+
     assert!(xss_info.is_some());
     let xss_info = xss_info.unwrap();
-    
+
     // XSS prompt should contain relevant keywords (English or Japanese)
-    assert!(xss_info.prompt.contains("XSS") || 
-           xss_info.prompt.contains("スクリプト") ||
-           xss_info.prompt.contains("HTML") ||
-           xss_info.prompt.contains("Cross-Site Scripting"));
+    assert!(
+        xss_info.prompt.contains("XSS")
+            || xss_info.prompt.contains("スクリプト")
+            || xss_info.prompt.contains("HTML")
+            || xss_info.prompt.contains("Cross-Site Scripting")
+    );
     assert!(!xss_info.prompt.is_empty());
 }
 
@@ -182,16 +190,18 @@ fn test_xss_specific_prompt() {
 fn test_lfi_specific_prompt() {
     let vuln_info_map = vuln_specific::get_vuln_specific_info();
     let lfi_info = vuln_info_map.get(&VulnType::LFI);
-    
+
     assert!(lfi_info.is_some());
     let lfi_info = lfi_info.unwrap();
-    
+
     // LFI prompt should contain relevant keywords (English or Japanese)
-    assert!(lfi_info.prompt.contains("ファイル") || 
-           lfi_info.prompt.contains("パス") ||
-           lfi_info.prompt.contains("インクルード") ||
-           lfi_info.prompt.contains("Local File Inclusion") ||
-           lfi_info.prompt.contains("File"));
+    assert!(
+        lfi_info.prompt.contains("ファイル")
+            || lfi_info.prompt.contains("パス")
+            || lfi_info.prompt.contains("インクルード")
+            || lfi_info.prompt.contains("Local File Inclusion")
+            || lfi_info.prompt.contains("File")
+    );
     assert!(!lfi_info.prompt.is_empty());
 }
 
@@ -203,11 +213,11 @@ fn test_prompt_templates_formatting() {
         ANALYSIS_APPROACH_TEMPLATE,
         GUIDELINES_TEMPLATE,
     ];
-    
+
     for template in templates {
         // Templates should contain meaningful content (allow leading/trailing whitespace)
         assert!(!template.trim().is_empty());
-        
+
         // Templates should contain proper line breaks
         assert!(template.contains('\n'));
     }
@@ -216,7 +226,7 @@ fn test_prompt_templates_formatting() {
 #[test]
 fn test_evaluator_prompt_template() {
     use vulnhuntrs::prompts::EVALUATOR_PROMPT_TEMPLATE;
-    
+
     assert!(!EVALUATOR_PROMPT_TEMPLATE.is_empty());
     // The evaluator prompt should be for evaluation purposes
     assert!(EVALUATOR_PROMPT_TEMPLATE.len() > 50); // Should be substantial

--- a/tests/repo_test.rs
+++ b/tests/repo_test.rs
@@ -17,21 +17,39 @@ fn test_ruby_files_are_recognized() -> anyhow::Result<()> {
 #[test]
 fn test_matches_gitignore_leading_star() {
     assert!(RepoOps::matches_gitignore_pattern("error.log", "*.log"));
-    assert!(RepoOps::matches_gitignore_pattern("logs/error.log", "*.log"));
+    assert!(RepoOps::matches_gitignore_pattern(
+        "logs/error.log",
+        "*.log"
+    ));
     assert!(!RepoOps::matches_gitignore_pattern("error.txt", "*.log"));
 }
 
 #[test]
 fn test_matches_gitignore_trailing_star() {
-    assert!(RepoOps::matches_gitignore_pattern("build/output.o", "build/*"));
-    assert!(RepoOps::matches_gitignore_pattern("build/sub/obj.o", "build/*"));
-    assert!(!RepoOps::matches_gitignore_pattern("target/output.o", "build/*"));
+    assert!(RepoOps::matches_gitignore_pattern(
+        "build/output.o",
+        "build/*"
+    ));
+    assert!(RepoOps::matches_gitignore_pattern(
+        "build/sub/obj.o",
+        "build/*"
+    ));
+    assert!(!RepoOps::matches_gitignore_pattern(
+        "target/output.o",
+        "build/*"
+    ));
 }
 
 #[test]
 fn test_matches_gitignore_exact_match() {
-    assert!(RepoOps::matches_gitignore_pattern("src/main.rs", "src/main.rs"));
-    assert!(!RepoOps::matches_gitignore_pattern("src/lib.rs", "src/main.rs"));
+    assert!(RepoOps::matches_gitignore_pattern(
+        "src/main.rs",
+        "src/main.rs"
+    ));
+    assert!(!RepoOps::matches_gitignore_pattern(
+        "src/lib.rs",
+        "src/main.rs"
+    ));
 }
 
 #[test]

--- a/tests/response_unit_test.rs
+++ b/tests/response_unit_test.rs
@@ -1,6 +1,8 @@
+use serde_json::{Value, json};
 use std::path::PathBuf;
-use vulnhuntrs::response::{Response, VulnType, ContextCode, AnalysisSummary, response_json_schema};
-use serde_json::{json, Value};
+use vulnhuntrs::response::{
+    AnalysisSummary, ContextCode, Response, VulnType, response_json_schema,
+};
 
 #[test]
 fn test_vuln_type_serialization() {
@@ -14,19 +16,25 @@ fn test_vuln_type_serialization() {
         VulnType::IDOR,
         VulnType::Other("Custom".to_string()),
     ];
-    
+
     let serialized = serde_json::to_string(&vuln_types).unwrap();
     let deserialized: Vec<VulnType> = serde_json::from_str(&serialized).unwrap();
-    
+
     assert_eq!(vuln_types, deserialized);
 }
 
 #[test]
 fn test_vuln_type_equality() {
     assert_eq!(VulnType::LFI, VulnType::LFI);
-    assert_eq!(VulnType::Other("test".to_string()), VulnType::Other("test".to_string()));
+    assert_eq!(
+        VulnType::Other("test".to_string()),
+        VulnType::Other("test".to_string())
+    );
     assert_ne!(VulnType::LFI, VulnType::RCE);
-    assert_ne!(VulnType::Other("test1".to_string()), VulnType::Other("test2".to_string()));
+    assert_ne!(
+        VulnType::Other("test1".to_string()),
+        VulnType::Other("test2".to_string())
+    );
 }
 
 #[test]
@@ -37,7 +45,7 @@ fn test_context_code_creation() {
         code_line: "eval(user_input)".to_string(),
         path: "/src/vulnerable.py".to_string(),
     };
-    
+
     assert_eq!(context.name, "vulnerable_function");
     assert_eq!(context.reason, "Uses unsafe eval() function");
     assert_eq!(context.code_line, "eval(user_input)");
@@ -59,7 +67,7 @@ fn test_response_creation() {
             path: "/src/handlers.py".to_string(),
         }],
     };
-    
+
     assert_eq!(response.confidence_score, 9);
     assert_eq!(response.vulnerability_types.len(), 1);
     assert_eq!(response.context_code.len(), 1);
@@ -76,32 +84,45 @@ fn test_response_serialization() {
         vulnerability_types: vec![VulnType::SQLI, VulnType::XSS],
         context_code: vec![],
     };
-    
+
     let serialized = serde_json::to_string(&response).unwrap();
     let deserialized: Response = serde_json::from_str(&serialized).unwrap();
-    
+
     assert_eq!(response.confidence_score, deserialized.confidence_score);
-    assert_eq!(response.vulnerability_types, deserialized.vulnerability_types);
+    assert_eq!(
+        response.vulnerability_types,
+        deserialized.vulnerability_types
+    );
 }
 
 #[test]
 fn test_response_json_schema() {
     let schema = response_json_schema();
-    
+
     // Verify schema structure
     assert_eq!(schema["type"], "object");
-    
+
     let properties = &schema["properties"];
     assert!(properties["scratchpad"]["type"] == "string");
     assert!(properties["analysis"]["type"] == "string");
     assert!(properties["poc"]["type"] == "string");
     assert!(properties["confidence_score"]["type"] == "integer");
-    
+
     // Check vulnerability types array schema
     let vuln_types = &properties["vulnerability_types"];
     assert_eq!(vuln_types["type"], "array");
-    assert!(vuln_types["items"]["enum"].as_array().unwrap().contains(&json!("RCE")));
-    assert!(vuln_types["items"]["enum"].as_array().unwrap().contains(&json!("SQLI")));
+    assert!(
+        vuln_types["items"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("RCE"))
+    );
+    assert!(
+        vuln_types["items"]["enum"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("SQLI"))
+    );
 }
 
 #[test]
@@ -131,9 +152,9 @@ fn test_markdown_generation() {
             path: "/test/path.py".to_string(),
         }],
     };
-    
+
     let markdown = response.to_markdown();
-    
+
     // Verify markdown contains expected sections
     assert!(markdown.contains("# 解析レポート"));
     assert!(markdown.contains("信頼度スコア: 8"));
@@ -151,7 +172,7 @@ fn test_markdown_generation() {
 fn test_confidence_score_validation() {
     // Test various confidence scores
     let scores = [0, 1, 5, 10, -1, 15];
-    
+
     for score in scores {
         let response = Response {
             scratchpad: String::new(),
@@ -161,7 +182,7 @@ fn test_confidence_score_validation() {
             vulnerability_types: vec![],
             context_code: vec![],
         };
-        
+
         // Confidence score should be stored as-is (validation is handled elsewhere)
         assert_eq!(response.confidence_score, score);
     }
@@ -177,7 +198,7 @@ fn test_empty_response() {
         vulnerability_types: vec![],
         context_code: vec![],
     };
-    
+
     assert!(response.scratchpad.is_empty());
     assert!(response.analysis.is_empty());
     assert!(response.poc.is_empty());
@@ -194,10 +215,10 @@ fn test_context_code_serialization() {
         code_line: "print('test')".to_string(),
         path: "/path/to/file.py".to_string(),
     };
-    
+
     let serialized = serde_json::to_string(&context).unwrap();
     let deserialized: ContextCode = serde_json::from_str(&serialized).unwrap();
-    
+
     assert_eq!(context.name, deserialized.name);
     assert_eq!(context.reason, deserialized.reason);
     assert_eq!(context.code_line, deserialized.code_line);
@@ -227,7 +248,7 @@ fn test_response_with_multiple_context_codes() {
             },
         ],
     };
-    
+
     assert_eq!(response.context_code.len(), 2);
     assert_eq!(response.context_code[0].name, "func1");
     assert_eq!(response.context_code[1].name, "func2");

--- a/tests/security_patterns_unit_test.rs
+++ b/tests/security_patterns_unit_test.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use vulnhuntrs::security_patterns::{
     Language, LanguagePatterns, PatternConfig, PatternType, SecurityRiskPatterns,
 };
@@ -13,10 +12,16 @@ fn test_language_from_extension() {
     assert_eq!(Language::from_extension("java"), Language::Java);
     assert_eq!(Language::from_extension("go"), Language::Go);
     assert_eq!(Language::from_extension("rb"), Language::Ruby);
+    assert_eq!(Language::from_extension("c"), Language::C);
+    assert_eq!(Language::from_extension("h"), Language::C);
+    assert_eq!(Language::from_extension("cpp"), Language::Cpp);
+    assert_eq!(Language::from_extension("cxx"), Language::Cpp);
+    assert_eq!(Language::from_extension("cc"), Language::Cpp);
+    assert_eq!(Language::from_extension("hpp"), Language::Cpp);
+    assert_eq!(Language::from_extension("hxx"), Language::Cpp);
 
     // Test unknown extensions
     assert_eq!(Language::from_extension("txt"), Language::Other);
-    assert_eq!(Language::from_extension("cpp"), Language::Other);
     assert_eq!(Language::from_extension(""), Language::Other);
     assert_eq!(Language::from_extension("unknown"), Language::Other);
 }
@@ -116,7 +121,7 @@ fn test_language_patterns_partial() {
 
 #[test]
 fn test_security_risk_patterns_new() {
-    let patterns = SecurityRiskPatterns::new(Language::Python);
+    let _patterns = SecurityRiskPatterns::new(Language::Python);
     // The constructor doesn't return Result, it creates an instance directly
     assert!(true); // Just test that it doesn't panic
 }

--- a/tests/security_patterns_unit_test.rs
+++ b/tests/security_patterns_unit_test.rs
@@ -1,5 +1,7 @@
-use vulnhuntrs::security_patterns::{Language, PatternType, PatternConfig, LanguagePatterns, SecurityRiskPatterns};
 use std::collections::HashMap;
+use vulnhuntrs::security_patterns::{
+    Language, LanguagePatterns, PatternConfig, PatternType, SecurityRiskPatterns,
+};
 
 #[test]
 fn test_language_from_extension() {
@@ -11,7 +13,7 @@ fn test_language_from_extension() {
     assert_eq!(Language::from_extension("java"), Language::Java);
     assert_eq!(Language::from_extension("go"), Language::Go);
     assert_eq!(Language::from_extension("rb"), Language::Ruby);
-    
+
     // Test unknown extensions
     assert_eq!(Language::from_extension("txt"), Language::Other);
     assert_eq!(Language::from_extension("cpp"), Language::Other);
@@ -38,7 +40,7 @@ fn test_pattern_type_equality() {
     assert_eq!(PatternType::Source, PatternType::Source);
     assert_eq!(PatternType::Sink, PatternType::Sink);
     assert_eq!(PatternType::Validate, PatternType::Validate);
-    
+
     assert_ne!(PatternType::Source, PatternType::Sink);
     assert_ne!(PatternType::Sink, PatternType::Validate);
     assert_ne!(PatternType::Source, PatternType::Validate);
@@ -50,7 +52,7 @@ fn test_pattern_config_creation() {
         pattern: "eval\\(".to_string(),
         description: "Dynamic code execution".to_string(),
     };
-    
+
     assert_eq!(config.pattern, "eval\\(");
     assert_eq!(config.description, "Dynamic code execution");
 }
@@ -67,20 +69,18 @@ fn test_language_patterns_creation() {
             description: "HTTP request parameter".to_string(),
         },
     ];
-    
-    let sinks = vec![
-        PatternConfig {
-            pattern: "eval\\(".to_string(),
-            description: "Code execution".to_string(),
-        },
-    ];
-    
+
+    let sinks = vec![PatternConfig {
+        pattern: "eval\\(".to_string(),
+        description: "Code execution".to_string(),
+    }];
+
     let patterns = LanguagePatterns {
         sources: Some(sources.clone()),
         sinks: Some(sinks.clone()),
         validate: None,
     };
-    
+
     assert!(patterns.sources.is_some());
     assert!(patterns.sinks.is_some());
     assert_eq!(patterns.sources.unwrap().len(), 2);
@@ -94,7 +94,7 @@ fn test_language_patterns_empty() {
         sinks: None,
         validate: None,
     };
-    
+
     assert!(patterns.sources.is_none());
     assert!(patterns.sinks.is_none());
 }
@@ -109,7 +109,7 @@ fn test_language_patterns_partial() {
         sinks: None,
         validate: None,
     };
-    
+
     assert!(patterns.sources.is_some());
     assert!(patterns.sinks.is_none());
 }
@@ -130,12 +130,12 @@ fn test_security_risk_patterns_new() {
 #[test]
 fn test_language_hash_and_equality() {
     use std::collections::HashSet;
-    
+
     let mut set = HashSet::new();
     set.insert(Language::Python);
     set.insert(Language::JavaScript);
     set.insert(Language::Python); // Duplicate
-    
+
     assert_eq!(set.len(), 2); // Should only contain 2 unique languages
     assert!(set.contains(&Language::Python));
     assert!(set.contains(&Language::JavaScript));
@@ -159,10 +159,10 @@ fn test_language_clone() {
 #[test]
 fn test_pattern_config_deserialization() {
     use serde_json;
-    
+
     let json_data = r#"{"pattern": "test_pattern", "description": "test description"}"#;
     let config: Result<PatternConfig, _> = serde_json::from_str(json_data);
-    
+
     assert!(config.is_ok());
     let config = config.unwrap();
     assert_eq!(config.pattern, "test_pattern");
@@ -172,16 +172,16 @@ fn test_pattern_config_deserialization() {
 #[test]
 fn test_language_patterns_deserialization() {
     use serde_json;
-    
+
     let json_data = r#"{
         "sources": [{"pattern": "input", "description": "User input"}],
         "sinks": [{"pattern": "eval", "description": "Code execution"}],
         "validate": null
     }"#;
-    
+
     let patterns: Result<LanguagePatterns, _> = serde_json::from_str(json_data);
     assert!(patterns.is_ok());
-    
+
     let patterns = patterns.unwrap();
     assert!(patterns.sources.is_some());
     assert!(patterns.sinks.is_some());


### PR DESCRIPTION
## Summary

This PR resolves the CI failures in Security Audit checks that were blocking PR merges by:

- Replacing unmaintained `dotenv` with `dotenvy` for better maintenance
- Adding `deny.toml` configuration to allow required licenses (Unicode-3.0, AGPL-3.0, CDLA-Permissive-2.0)
- Upgrading tree-sitter from 0.24.6 to 0.25.6 for compatibility
- Adding C/C++ language support to Language enum and file extensions

## Changes Made

- **Dependencies**: Replaced `dotenv` with `dotenvy` in Cargo.toml and main.rs
- **License Configuration**: Created deny.toml with allowed licenses to pass cargo-deny checks
- **Tree-sitter Upgrade**: Updated to version 0.25.6 to resolve parser compatibility
- **Language Support**: Extended Language enum with C and Cpp variants
- **File Extensions**: Added support for .c, .h, .cpp, .cxx, .cc, .hpp, .hxx files

## Test Plan

- [x] `cargo build --release` succeeds
- [x] `cargo check` passes
- [x] `cargo deny check licenses` passes
- [x] All language enum matches are updated consistently

This should resolve the Security Audit CI failures and allow blocked PRs to merge.

🤖 Generated with [Claude Code](https://claude.ai/code)